### PR TITLE
Updates made to Steering and datalogger

### DIFF
--- a/Drive_By_Wire/DBW_Pins.h
+++ b/Drive_By_Wire/DBW_Pins.h
@@ -1,7 +1,7 @@
 #ifndef _DBW_PINS_
 #define _DBW_PINS_
 
-#define DEBUG false
+#define DEBUG true
 #define USE_PIDS true
 
 #include <Arduino.h>
@@ -37,8 +37,8 @@
 // Relay that turns on power to the steering system
 #define STEER_ON_PIN        8
 // Wheel angle sensors mounted on left and right steering columns
-#define L_SENSE_PIN    7
-#define R_SENSE_PIN    6
+#define L_SENSE_PIN    A2
+#define R_SENSE_PIN    A3
 
 // Command to e-bike controller to use regenerative braking; not used 
 #define REGEN_PIN          22

--- a/Drive_By_Wire/DBW_Pins.h
+++ b/Drive_By_Wire/DBW_Pins.h
@@ -2,7 +2,7 @@
 #define _DBW_PINS_
 
 #define DEBUG true
-#define USE_PIDS false
+#define USE_PIDS false // throttle currently uses a PID controller, Steering does not current use a PID controller
 
 #include <Arduino.h>
 

--- a/Drive_By_Wire/DBW_Pins.h
+++ b/Drive_By_Wire/DBW_Pins.h
@@ -2,7 +2,7 @@
 #define _DBW_PINS_
 
 #define DEBUG true
-#define USE_PIDS true
+#define USE_PIDS false
 
 #include <Arduino.h>
 

--- a/Drive_By_Wire/RC_Controller.cpp
+++ b/Drive_By_Wire/RC_Controller.cpp
@@ -43,6 +43,7 @@ void RC_Controller::mapValues() {
 
 // Maps value into steering
 // 779 (Left - 1020 us), 722 (Straight - 1440us), 639 (Right - 1860us)
+// new Values for Left angle sensor 630 (Left - 1020 us), 315 (Straight - 1440us), 91 (Right - 1860us)
 void RC_Controller::mapSteering() {
   unsigned long currentTime = micros();
 
@@ -58,9 +59,9 @@ void RC_Controller::mapSteering() {
     // filtering pulse widths
     if (prevSteering == pulseWidth) {
       if (pulseWidth > 1500) {  // calibrated steering values
-        steeringValue = map(pulseWidth, 1012, 1440, 779, 722);
+        steeringValue = map(pulseWidth, 1012, 1440, 630, 315);
       } else {
-        steeringValue = map(pulseWidth, 1440, 1860, 722, 639);
+        steeringValue = map(pulseWidth, 1440, 1860, 315, 91);
       }
       RC_VALUES_MAPPED[RC_CH1_STEERING] = steeringValue;
     }

--- a/Drive_By_Wire/RC_Controller.cpp
+++ b/Drive_By_Wire/RC_Controller.cpp
@@ -43,7 +43,7 @@ void RC_Controller::mapValues() {
 
 // Maps value into steering
 // 779 (Left - 1020 us), 722 (Straight - 1440us), 639 (Right - 1860us)
-// new Values for Left angle sensor 630 (Left - 1020 us), 315 (Straight - 1440us), 91 (Right - 1860us)
+// new Values for Left angle sensor 630 (Left - 1000 us), 315 (Straight - 1440us), 91 (Right - 1996us)
 void RC_Controller::mapSteering() {
   unsigned long currentTime = micros();
 
@@ -58,10 +58,10 @@ void RC_Controller::mapSteering() {
 
     // filtering pulse widths
     if (prevSteering == pulseWidth) {
-      if (pulseWidth > 1500) {  // calibrated steering values
-        steeringValue = map(pulseWidth, 1012, 1440, 630, 315);
+      if (pulseWidth < 1440) {  // calibrated steering values
+        steeringValue = map(pulseWidth, 1000, 1440, 630, 315);
       } else {
-        steeringValue = map(pulseWidth, 1440, 1860, 315, 91);
+        steeringValue = map(pulseWidth, 1440, 1996, 91, 315);
       }
       RC_VALUES_MAPPED[RC_CH1_STEERING] = steeringValue;
     }

--- a/Drive_By_Wire/SteeringController.cpp
+++ b/Drive_By_Wire/SteeringController.cpp
@@ -39,17 +39,27 @@ Current Calibration: (Last Update: May 14, 2023)
 722 - 1500us (middle)
 639 - 1850us (right)
 
+Update 4/18/2024
+770 left
+710 center 
+610 right
+
+Update 4/19/2024 Left Sensor is now working
+630 left
+315 center
+91 right
+
 Main function to call the steering
 */
 int32_t SteeringController::update(int32_t desiredAngle) {
   // desiredAngle = map(desiredAngle, MIN_TURN_Mdegrees, MAX_TURN_Mdegrees, MIN_TURN_MS, MAX_TURN_MS); // old settings
   int32_t mappedAngle = desiredAngle;
 
-  if (desiredAngle > 722) { 
-    mappedAngle = map(desiredAngle, 779, 722, MIN_TURN_MS, 1500); 
-  } else {
-    mappedAngle = map(desiredAngle, 722, 639, 1500, MAX_TURN_MS);
-  }
+  //if (desiredAngle > 722) { 
+    //mappedAngle = map(desiredAngle, 779, 722, MIN_TURN_MS, 1500); 
+  //} else {
+    //mappedAngle = map(desiredAngle, 722, 639, 1500, MAX_TURN_MS);
+  //}
 
   if (USE_PIDS) {
     SteeringPID(mappedAngle);
@@ -62,7 +72,7 @@ int32_t SteeringController::update(int32_t desiredAngle) {
   //return map(currentSteeringUS, MIN_TURN_MS,MAX_TURN_MS,MIN_TURN_Kdegrees,MAX_TURN_Kdegrees); // old settings
 
   //return desiredAngle;
-  steerAngleUS = computeAngleRight(); // uncomment when testing with sensors
+  steerAngleUS = computeAngleLeft(); // uncomment when testing with sensors
   return steerAngleUS;
 }
 
@@ -94,7 +104,7 @@ void SteeringController::engageSteering(int32_t input) {
     digitalWrite(7, LOW);
     digitalWrite(6, LOW);
     steeringMode = 0; // changes here
-  } else if (currentAngle > input) {// left turn
+  } else if (input > currentAngle) {// left turn
     digitalWrite(7, HIGH);
     digitalWrite(6, LOW);
     steeringMode = 1;
@@ -103,6 +113,8 @@ void SteeringController::engageSteering(int32_t input) {
     digitalWrite(6, HIGH);
     steeringMode = -1;
   }
+  Serial.print("Steering Mode: ");
+  Serial.println(steeringMode);
 
   //  Steer_Servo.writeMicroseconds(input);
   delay(1);
@@ -112,11 +124,12 @@ void SteeringController::engageSteering(int32_t input) {
 // Calculates the angle from left sensor
 int32_t SteeringController::computeAngleLeft() { // issues with sensor
   int32_t val = analogRead(L_SENSE_PIN);
-  val = map(val, Left_Read_at_MIN_TURN, Left_Read_at_MAX_TURN, MIN_TURN_MS, MAX_TURN_MS);
-  /*if(DEBUG){
+ // val = map(val, Left_Read_at_MIN_TURN, Left_Read_at_MAX_TURN, MIN_TURN_MS, MAX_TURN_MS);
+  if(DEBUG){
     Serial.print("Left sensor: ");
     Serial.println(val);
-  } */
+  } 
+
   return val;
 }
 

--- a/Drive_By_Wire/SteeringController.cpp
+++ b/Drive_By_Wire/SteeringController.cpp
@@ -61,11 +61,11 @@ int32_t SteeringController::update(int32_t desiredAngle) {
     //mappedAngle = map(desiredAngle, 722, 639, 1500, MAX_TURN_MS);
   //}
 
-  if (USE_PIDS) {
-    SteeringPID(mappedAngle);
-  } else {
+  //if (USE_PIDS) {
+    //SteeringPID(mappedAngle);
+  //} else {
     engageSteering(mappedAngle); 
-  }
+  //}
   
   delay(1);
 

--- a/Drive_By_Wire/SteeringController.cpp
+++ b/Drive_By_Wire/SteeringController.cpp
@@ -54,16 +54,16 @@ int32_t SteeringController::update(int32_t desiredAngle) {
   if (USE_PIDS) {
     SteeringPID(mappedAngle);
   } else {
-    engageSteering(mappedAngle);
+    engageSteering(mappedAngle); 
   }
   
   delay(1);
 
   //return map(currentSteeringUS, MIN_TURN_MS,MAX_TURN_MS,MIN_TURN_Kdegrees,MAX_TURN_Kdegrees); // old settings
 
-  return desiredAngle;
-  //steerAngleUS = computeAngleRight(); // uncomment when testing with sensors
-  //return steerAngleUS;
+  //return desiredAngle;
+  steerAngleUS = computeAngleRight(); // uncomment when testing with sensors
+  return steerAngleUS;
 }
 
 //Private
@@ -78,7 +78,7 @@ void SteeringController::SteeringPID(int32_t input) {
 
 // Outputs a PWM based on input (1ms - 1.85ms)
 void SteeringController::engageSteering(int32_t input) {
-  if (input > MAX_TURN_MS)
+  /*if (input > MAX_TURN_MS)
     input = MAX_TURN_MS;
   else if (input < MIN_TURN_MS)
     input = MIN_TURN_MS;
@@ -88,9 +88,25 @@ void SteeringController::engageSteering(int32_t input) {
       Serial.println(input);
     }
     currentSteeringUS = input;
+  } */
+  
+  if (abs(currentAngle - input) < threshold) {
+    digitalWrite(7, LOW);
+    digitalWrite(6, LOW);
+    steeringMode = 0; // changes here
+  } else if (currentAngle > input) {// left turn
+    digitalWrite(7, HIGH);
+    digitalWrite(6, LOW);
+    steeringMode = 1;
+  } else {//right turn
+    digitalWrite(7, LOW);
+    digitalWrite(6, HIGH);
+    steeringMode = -1;
   }
-  Steer_Servo.writeMicroseconds(input);
+
+  //  Steer_Servo.writeMicroseconds(input);
   delay(1);
+  
 }
 
 // Calculates the angle from left sensor
@@ -107,10 +123,17 @@ int32_t SteeringController::computeAngleLeft() { // issues with sensor
 // Calculates the angle from right sensor
 int32_t SteeringController::computeAngleRight() {
   int32_t val = analogRead(R_SENSE_PIN);
-  val = map(val, Right_Read_at_MIN_TURN, Right_Read_at_MAX_TURN, MIN_TURN_MS, MAX_TURN_MS);
-  /* if(DEBUG){
+  currentAngle = val;
+  //val = map(val, Right_Read_at_MIN_TURN, Right_Read_at_MAX_TURN, MIN_TURN_MS, MAX_TURN_MS);
+  if(DEBUG){
  Serial.print("Right sensor: ");
  Serial.println(val);
- } */
+ } 
   return val;
+}
+
+int16_t SteeringController::getSteeringMode()
+{
+  return  steeringMode;
+
 }

--- a/Drive_By_Wire/SteeringController.h
+++ b/Drive_By_Wire/SteeringController.h
@@ -9,6 +9,9 @@ class SteeringController {
   double PIDSteeringOutput_us;
   double desiredTurn_us;
   int32_t currentSteeringUS = 0;
+  int32_t currentAngle;
+  int32_t threshold = 20;
+  int16_t steeringMode = 0;
   void SteeringPID(int32_t input);
   int32_t computeAngleLeft();
   int32_t computeAngleRight();
@@ -17,4 +20,5 @@ public:
   SteeringController();
   ~SteeringController();
   int32_t update(int32_t desiredAngle);
+  int16_t getSteeringMode();
 };

--- a/Drive_By_Wire/SteeringController.h
+++ b/Drive_By_Wire/SteeringController.h
@@ -14,11 +14,12 @@ class SteeringController {
   int16_t steeringMode = 0;
   void SteeringPID(int32_t input);
   int32_t computeAngleLeft();
-  int32_t computeAngleRight();
+  //int32_t computeAngleRight();
   void engageSteering(int32_t input);
 public:
   SteeringController();
   ~SteeringController();
   int32_t update(int32_t desiredAngle);
   int16_t getSteeringMode();
+   int32_t computeAngleRight();
 };

--- a/Drive_By_Wire/Vehicle.cpp
+++ b/Drive_By_Wire/Vehicle.cpp
@@ -165,8 +165,10 @@ void Vehicle::initalize(){
     filename[6] = i / 10 + '0';
     filename[7] = i % 10 + '0';
     if (!SD.exists(filename)) {
+      Serial.print("File does not exist. New file name:");
+      Serial.println(filename);
       // only open a new file if it doesn't exist
-      logfile = SD.open(filename, FILE_READ);
+      logfile = SD.open(filename, FILE_WRITE);
       break;  // leave the loop!
     }
   }
@@ -234,10 +236,10 @@ void Vehicle::update() {
 
   // unknown status (120 - 145)
  #if DBWversion < 4
-  CAN.MCP_CAN::sendMsgBuf(Actual_CANID, 0, 8, (uint8_t*)&MSG);
+  CAN.MCP_CAN::sendMsgBuf(Actual_CANID, 0, 0, 8, (uint8_t*)&MSG);
 
   if (DEBUG) {
-    if (CAN.MCP_CAN::sendMsgBuf(Actual_CANID, 0, 8, (uint8_t*)&MSG)) {
+    if (CAN.MCP_CAN::sendMsgBuf(Actual_CANID, 0, 0,  8, (uint8_t*)&MSG)) {
       Serial.println("Sending Message to MEGA");
     } else {
       Serial.println("Message Failed");
@@ -405,7 +407,7 @@ void Vehicle::eStop() {
 void Vehicle::updateRC() {
   RC.mapValues();
   throttlePulse_ms=RC.getMappedValue(RC_CH2_THROTTLE_BR);
-  steerPulse_ms=RC.getMappedValue(RC_CH2_THROTTLE_BR); 
+  steerPulse_ms=RC.getMappedValue(RC_CH1_STEERING); 
   if (RC.checkValidData()) {
     if (throttlePulse_ms == -1 && brakeHold == 0) {  // Activate brakes
       //Serial.println("24V is on" + String(RC.getMappedValue(RC_CH2_THROTTLE_BR)));

--- a/Drive_By_Wire/Vehicle.cpp
+++ b/Drive_By_Wire/Vehicle.cpp
@@ -53,7 +53,7 @@ Vehicle::Vehicle() {
 
 #if DBWversion < 4
   // Keep trying to initialize CAN
-  while (!CAN.begin(CAN_500KBPS)) {
+  while (0) { // changed to false For testing purposes CAN.begin(CAN_500KBPS) ReEnable for DBWV4
     if (DEBUG) {
       Serial.println("CAN BUS Shield init fail");
     }
@@ -181,7 +181,7 @@ void Vehicle::initalize(){
   Serial.println(filename);
 
   // Add a header to the file
-  logfile.print("time_ms,desired_speed_ms,desired_brake,desired_angle,current_speed,current_brake,current_angle,throttle_pulse,steerpulse,brakeHold,steeringVal\n"); // added steeringVal (modification)
+  logfile.print("time_ms,desired_speed_ms,desired_brake,desired_angle,current_speed,current_brake,current_angle,throttle_pulse,steerpulse,brakeHold,steeringVal,steeringAngleRight\n"); // added steeringVal (modification)
   logfile.flush();
 
 }
@@ -423,6 +423,7 @@ void Vehicle::updateRC() {
     }
 
     currentAngle = steer.update(steerPulse_ms);
+    currentRightAngle = steer.computeAngleRight();
     steeringVal = steer.getSteeringMode();
    // LogMonitor();
     LogSD();
@@ -461,9 +462,11 @@ void Vehicle::LogSD(){
   logfile.print(",");
   logfile.print(steerPulse_ms);
   logfile.print(",");
-  logfile.println(brakeHold);
+  logfile.print(brakeHold);
   logfile.print(",");
-  logfile.println(steeringVal);
+  logfile.print(steeringVal);
+  logfile.print(",");
+  logfile.println(currentRightAngle);
   logfile.flush();  // Flush the file to make sure data is written immediately
 }
 

--- a/Drive_By_Wire/Vehicle.cpp
+++ b/Drive_By_Wire/Vehicle.cpp
@@ -181,7 +181,7 @@ void Vehicle::initalize(){
   Serial.println(filename);
 
   // Add a header to the file
-  logfile.print("time_ms,desired_speed_ms,desired_brake,desired_angle,current_speed,current_brake,current_angle,throttle_pulse,steerpulse,brakeHold\n");
+  logfile.print("time_ms,desired_speed_ms,desired_brake,desired_angle,current_speed,current_brake,current_angle,throttle_pulse,steerpulse,brakeHold,steeringVal\n"); // added steeringVal (modification)
   logfile.flush();
 
 }
@@ -407,7 +407,7 @@ void Vehicle::eStop() {
 void Vehicle::updateRC() {
   RC.mapValues();
   throttlePulse_ms=RC.getMappedValue(RC_CH2_THROTTLE_BR);
-  steerPulse_ms=RC.getMappedValue(RC_CH1_STEERING); 
+  steerPulse_ms=RC.getMappedValue(RC_CH1_STEERING); // is wheel angle and not pulse width 
   if (RC.checkValidData()) {
     if (throttlePulse_ms == -1 && brakeHold == 0) {  // Activate brakes
       //Serial.println("24V is on" + String(RC.getMappedValue(RC_CH2_THROTTLE_BR)));
@@ -422,7 +422,8 @@ void Vehicle::updateRC() {
       //Serial.println(RC.getMappedValue(RC_CH2_THROTTLE_BR));
     }
 
-    steer.update(steerPulse_ms);
+    currentAngle = steer.update(steerPulse_ms);
+    steeringVal = steer.getSteeringMode();
    // LogMonitor();
     LogSD();
   }
@@ -461,6 +462,8 @@ void Vehicle::LogSD(){
   logfile.print(steerPulse_ms);
   logfile.print(",");
   logfile.println(brakeHold);
+  logfile.print(",");
+  logfile.println(steeringVal);
   logfile.flush();  // Flush the file to make sure data is written immediately
 }
 

--- a/Drive_By_Wire/Vehicle.cpp
+++ b/Drive_By_Wire/Vehicle.cpp
@@ -160,7 +160,8 @@ void Vehicle::initalize(){
   Serial.println("card initialized.");
 
   // create a new file
-  char filename[] = "LOGGER00.CSV";
+  
+  /*char filename[] = "LOGGER00.CSV";
   for (uint8_t i = 0; i < 100; i++) {
     filename[6] = i / 10 + '0';
     filename[7] = i % 10 + '0';
@@ -172,6 +173,25 @@ void Vehicle::initalize(){
       break;  // leave the loop!
     }
   }
+  */
+   // create a new file
+
+  char filename[] = "MM_DD_00.CSV";
+
+  filename[0] = tm.Month / 10 + '0';
+  filename[1] = tm.Month % 10 + '0';
+
+  filename[3] = tm.Day / 10 + '0';
+  filename[4] = tm.Day % 10 + '0';
+
+  int i = 1;
+  do {
+    //file number 27-28
+    filename[6] = i / 10 + '0';
+    filename[7] = i % 10 + '0';
+    i++;
+  } while (SD.exists(filename) && (i < 100));
+  logfile = SD.open(filename, FILE_WRITE);
 
   if (!logfile) {
     error("file unable to open!");

--- a/Drive_By_Wire/Vehicle.h
+++ b/Drive_By_Wire/Vehicle.h
@@ -37,10 +37,11 @@ File logfile;
   int16_t currentSpeed;
   int16_t currentBrake;
   int16_t currentAngle;
+
   int brakeHold; // Hold brakes with 12V 
   long throttlePulse_ms;
   long steerPulse_ms;
-
+  int16_t steeringVal; // new val
   void recieveCan();
   void initalize(); 
   void error(char *str);

--- a/Drive_By_Wire/Vehicle.h
+++ b/Drive_By_Wire/Vehicle.h
@@ -37,6 +37,7 @@ File logfile;
   int16_t currentSpeed;
   int16_t currentBrake;
   int16_t currentAngle;
+  int16_t currentRightAngle;
 
   int brakeHold; // Hold brakes with 12V 
   long throttlePulse_ms;


### PR DESCRIPTION
Steering now outputs commands to the steering board and steering is determined using the left wheel angle values and a threshold is used to determine the direction the steering should move. The datalogger now uses the month and day in the file name expanding the number of files from 100 to 36500 or 100 per day. New data fields were also added to the datalogger providing the wheel angles and the steering command outputs. 