### PR TITLE
Create Arduino DBW Receiver code

### DIFF
--- a/Arduino DBW Receiver code
+++ b/Arduino DBW Receiver code
@@ -1,0 +1,69 @@
+#include <due_can.h>
+#define DBW_STEERING_PIN  2   // PWM or analog control
+#define DBW_THROTTLE_PIN  3
+#define DBW_BRAKE_PIN     4
+
+
+void setup() {
+  Serial.begin(115200);
+  Can0.begin(CAN_BPS_500K);
+
+
+  // Optionally set mailboxes manually if needed
+  for (int i = 0; i < 8; i++) {
+    Can0.setRXFilter(i, 0x200, 0x7FF, false);  // Accept messages with ID 0x200
+  }
+
+
+  // Setup outputs
+  pinMode(DBW_STEERING_PIN, OUTPUT);
+  pinMode(DBW_THROTTLE_PIN, OUTPUT);
+  pinMode(DBW_BRAKE_PIN, OUTPUT);
+
+
+  analogWrite(DBW_STEERING_PIN, 90); // Neutral PWM
+  analogWrite(DBW_THROTTLE_PIN, 0);
+  analogWrite(DBW_BRAKE_PIN, 0);
+
+
+  Serial.println("CAN Receiver Initialized.");
+}
+
+
+void loop() {
+  CAN_FRAME incoming;
+
+
+  if (Can0.available()) {
+    Can0.read(incoming);
+
+
+    if (incoming.id == 0x200 && incoming.length >= 2) {
+      byte cmd_id = incoming.data.byte[0];
+      int value = 0;
+
+
+      if (cmd_id == 0x01) {  // Steering (signed)
+        value = (int8_t)incoming.data.byte[1]; // cast signed
+        int pwm = map(value, -30, 30, 60, 120);  // Map to servo PWM range 
+        analogWrite(DBW_STEERING_PIN, pwm);
+        Serial.print("[STEERING] Angle: ");
+        Serial.println(value);
+      }
+      else if (cmd_id == 0x02) {  // Throttle
+        value = incoming.data.byte[1];
+        int pwm = map(value, 0, 100, 0, 255);
+        analogWrite(DBW_THROTTLE_PIN, pwm);
+        Serial.print("[THROTTLE] Value: ");
+        Serial.println(value);
+      }
+      else if (cmd_id == 0x03) {  // Brake
+        value = incoming.data.byte[1];
+        int pwm = map(value, 0, 100, 0, 255);
+        analogWrite(DBW_BRAKE_PIN, pwm);
+        Serial.print("[BRAKE] Value: ");
+        Serial.println(value);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Arduino code for the receival of CAN messages, not fully developed but required for receiving messages while running Jetson Nano Autonomous code.